### PR TITLE
Allow wireguard connections

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,5 @@ networkmanager_conf_d: {}
 #       gw4: 192.0.2.1
 #       state: present
 networkmanager_connections: []
+
+networkmanager_vpn_client_packages: []

--- a/molecule/wireguard/converge.yml
+++ b/molecule/wireguard/converge.yml
@@ -16,6 +16,8 @@
           public_key: 'KqOQG90uvqVWGHwLW+Z5tH019Qt5QcIhpKitIovkviA='
         dns4: ['10.10.10.89']
         dns4_search: 'svd.fdz.dezim-institut.de'
+    networkmanager_vpn_client_packages:
+      - wireguard-tools
   tasks:
     - name: "Include ansible-role-networkmanager"
       include_role:

--- a/molecule/wireguard/converge.yml
+++ b/molecule/wireguard/converge.yml
@@ -1,0 +1,22 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    networkmanager_connections:
+      - conn_name: 'wg_test'
+        ifname: 'wg_test'
+        type: 'wireguard'
+        ip4: '10.42.43.2/32'
+        wireguard:
+          peer: 'wireguard.example.com'
+          peer_port: 51820
+          allowed_ips: '10.10.10.0/24'
+          private_key: 'gDdP5JHM6VQQOeGZPLANiTMa+V2bbwyR8Z2o86m7gUg='
+          public_key: 'KqOQG90uvqVWGHwLW+Z5tH019Qt5QcIhpKitIovkviA='
+        dns4: ['10.10.10.89']
+        dns4_search: 'svd.fdz.dezim-institut.de'
+  tasks:
+    - name: "Include ansible-role-networkmanager"
+      include_role:
+        name: "ansible-role-networkmanager"

--- a/molecule/wireguard/molecule.yml
+++ b/molecule/wireguard/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+  options:
+    ignore-certs: true
+    ignore-errors: true
+driver:
+  name: vagrant
+platforms:
+  - name: vagrant-ubuntu
+    box: ubuntu/focal64
+    memory: 4048
+    cpus: 4
+    instance_raw_config_args:
+      - "vm.network 'forwarded_port', guest: 8081, host: 30080"
+provisioner:
+  name: ansible
+  lint: ansible-lint --force-color
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+verifier:
+  name: ansible

--- a/molecule/wireguard/prepare.yml
+++ b/molecule/wireguard/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare
+  hosts: all
+  become: true
+  tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_os_family == 'Debian'

--- a/molecule/wireguard/verify.yml
+++ b/molecule/wireguard/verify.yml
@@ -1,0 +1,39 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  vars:
+    conn_name: 'wg_test'
+    ifname: 'wg_test'
+    type: 'wireguard'
+    ip4: '10.42.43.2/32'
+    wireguard:
+      peer: 'wireguard.example.com'
+      peer_port: '51820'
+      allowed_ips: '10.10.10.0/24'
+      private_key: 'gDdP5JHM6VQQOeGZPLANiTMa+V2bbwyR8Z2o86m7gUg='
+      public_key: 'KqOQG90uvqVWGHwLW+Z5tH019Qt5QcIhpKitIovkviA='
+  become: true
+  become_user: root
+  tasks:
+    - name: Read wireguard config
+      ansible.builtin.slurp:
+        src: '/etc/NetworkManager/system-connections/wg_test.nmconnection'
+      register: wg_config_encoded
+
+    - name: Set wg config var
+      ansible.builtin.set_fact:
+        wg_config: "{{ wg_config_encoded.content | b64decode }}"
+
+    - name: Check wireguard config
+      ansible.builtin.assert:
+        that:
+          - ifname in wg_config
+          - ip4 in wg_config
+          - wireguard.peer in wg_config
+          - wireguard.peer_port in wg_config
+          - wireguard.allowed_ips in wg_config
+          - wireguard.private_key in wg_config
+          - wireguard.public_key in wg_config

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -31,3 +31,10 @@
   when:
     - ansible_os_family | lower != 'debian'
     - ansible_os_family | lower != 'redhat'
+
+- name: install vpn client packages
+  ansible.builtin.package:
+    name:
+      - "{{ item }}"
+    state: present
+  loop: "{{ networkmanager_vpn_client_packages }}"

--- a/tasks/manage_connections.yml
+++ b/tasks/manage_connections.yml
@@ -53,3 +53,52 @@
   loop: "{{ networkmanager_connections }}"
   loop_control:
     label: "{{ item.conn_name | default(ansible_default_ipv4.interface) }} to be {{ item.state | default('present') }}"
+  when: item.type != 'wireguard'
+
+- name: manage wireguard connections
+  community.general.nmcli:
+    wireguard:
+      fwmark: "{{ item.wireguard.fwmark | default(omit) }}"
+      listen-port: "{{ item.wireguard.listen_port | default(omit) }}"
+      ip4-auto-default-route: "{{ item.wireguard.ip4_auto_default_route | default(omit) }}"
+      ip6-auto-default-route: "{{ item.wireguard.ip6_auto_default_route | default(omit) }}"
+      mtu: "{{ item.wireguard.mtu | default(omit) }}"
+      peer-routes: "{{ item.wireguard.peer_routes | default(omit) }}"
+      private-key: "{{ item.wireguard.private_key | default(omit) }}"
+      private-key-flags: "{{ item.wireguard.private_key_flags | default(omit) }}"
+    autoconnect: "{{ item.autoconnect | default(omit) }}"
+    conn_name: "{{ item.conn_name }}"
+    dns4: "{{ item.dns4 | default(omit) }}"
+    dns4_search: "{{ item.dns4_search | default(omit) }}"
+    dns6: "{{ item.dns6 | default(omit) }}"
+    dns6_search: "{{ item.dns6_search | default(omit) }}"
+    gw4: "{{ item.gw4 | default(omit) }}"
+    gw6: "{{ item.gw6 | default(omit) }}"
+    ifname: "{{ item.ifname | default(omit) }}"
+    ip4: "{{ item.ip4 | default(omit) }}"
+    ip6: "{{ item.ip6 | default(omit) }}"
+    mac: "{{ item.mac | default(omit) }}"
+    mode: "{{ item.mode | default(omit) }}"
+    mtu: "{{ item.mtu | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
+    type: "{{ item.type }}"
+  notify: restart networkmanager
+  loop: "{{ networkmanager_connections }}"
+  loop_control:
+    label: "{{ item.conn_name | default(ansible_default_ipv4.interface) }} to be {{ item.state | default('present') }}"
+  when: item.type == 'wireguard'
+
+- name: Add wireguard peers
+  ansible.builtin.blockinfile:
+    path: "/etc/NetworkManager/system-connections/{{ item.conn_name }}.nmconnection"
+    insertbefore: '\[ipv4\]'
+    block: |
+      [wireguard-peer.{{ item.wireguard.public_key }}]
+      endpoint={{ item.wireguard.peer }}:{{ item.wireguard.peer_port }}
+      allowed-ips={{ item.wireguard.allowed_ips }};
+
+  notify: restart networkmanager
+  loop: "{{ networkmanager_connections }}"
+  loop_control:
+    label: "{{ item.conn_name | default(ansible_default_ipv4.interface) }} to be {{ item.state | default('present') }}"
+  when: item.type == 'wireguard'


### PR DESCRIPTION
While using your role I discovered that setting up wireguard tunnels is not supported yet.
I added capabilities to configure wireguard tunnel interfaces with the networkmanager role.
