### PR TITLE
Make variable networkmanager_config work

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ networkmanager_service_state: started
 networkmanager_service_restart_on_change: true
 
 # NetworkManager configuration
-networkmanager_conf: {}
+networkmanager_config: {}
 networkmanager_conf_d: {}
 
 # network connections

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -10,7 +10,7 @@
     lstrip_blocks: true
   notify: restart networkmanager
   vars:
-    cfg: "{{ __networkmanager_config_defaults | combine(networkmanager_conf, recursive=True) }}"
+    cfg: "{{ __networkmanager_config_defaults | combine(networkmanager_config, recursive=True) }}"
 
 - name: create NetworkManager configurations in conf.d
   ansible.builtin.template:


### PR DESCRIPTION
A new PR after remarks in and closing of PR #4 .

This PR is intended to fix an issue with non-working variable `networkmanager_config`. Documentation `README.md` mentions a variable `networkmanager_config` may be used to customize the main Networkmanager configuration. However setting this variable had no effect. A look at the code revealed why: the role code is looking for a variable called `networkmanager_conf`. After changing my group_vars I was able to set Networkmanager main configuration accordingly. The code works, the variable name simply does not match the documentation.

This PR changes the code to match the documentation regarding variable `networkmanager_config`.